### PR TITLE
correct names of ssl_key and ssl_crt variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Role Variables
 Template for site conf file:
 
     nginx_site_template: wsgi-site-conf.j2
-    
+
 Set site domain, must be a single non-wildcard DNS domain:
 
     nginx_server_name:
@@ -34,7 +34,7 @@ enough, but you can override:
     nginx_certbot_cert_filename: fullchain.pem
     nginx_certbot_privkey_filename: privkey.pem
 
-Ssl setup (if not using certbot); note: `ssl_key` should be kept secret!
+Ssl setup (if not using certbot); note: `nginx_ssl_key` should be kept secret!
 
     nginx_use_letsencrypt: no
     nginx_ssl_dest_dir: /etc/ssl
@@ -45,9 +45,9 @@ Ssl setup (if not using certbot); note: `ssl_key` should be kept secret!
     nginx_ssl_key: |
       -----BEGIN PRIVATE KEY-----
       ...
-      
+
 Upstream wsgi upstream name (`{{ nginx_wsgi_app }}-wsgi`) and servers
-(for wsgi-site-conf template). 
+(for wsgi-site-conf template).
 
     nginx_wsgi_app: webapp
     nginx_wsgi_port: 10000

--- a/tasks/build.yml
+++ b/tasks/build.yml
@@ -3,23 +3,23 @@
 - name: Fail if nginx_server_name is not set
   fail: msg="Set nginx_server_name is required"
   when: not nginx_server_name
-  
+
 - name: Fail if no SSL config
-  fail: msg="Either nginx_use_letsencrypt or valid ssl_crt and ssl_key required"
-  when: not nginx_use_letsencrypt and not (ssl_crt and ssl_key)
-  
+  fail: msg="Either nginx_use_letsencrypt or valid nginx_ssl_crt and nginx_ssl_key required"
+  when: not nginx_use_letsencrypt and not (nginx_ssl_crt and nginx_ssl_key)
+
 - name: Install Nginx
   apt: name=nginx update_cache=yes state=present
 
 - name: Copy the SSL certificate to the remote server
-  copy: content={{ ssl_crt }} dest={{ nginx_ssl_dest_dir }}/{{ nginx_server_name }}.crt
+  copy: content={{ nginx_ssl_crt }} dest={{ nginx_ssl_dest_dir }}/{{ nginx_server_name }}.crt
   notify: Restart Nginx
-  when: not nginx_use_letsencrypt and ssl_crt
+  when: not nginx_use_letsencrypt and nginx_ssl_crt
 
 - name: Copy the SSL private key to the remote server
-  copy: content={{ ssl_key }} dest={{ nginx_ssl_dest_dir }}/{{ nginx_server_name }}.key
+  copy: content={{ nginx_ssl_key }} dest={{ nginx_ssl_dest_dir }}/{{ nginx_server_name }}.key
   notify: Restart Nginx
-  when: not nginx_use_letsencrypt and ssl_key
+  when: not nginx_use_letsencrypt and nginx_ssl_key
 
 - name: Ensure that a strong Diffie-Hellman group is used
   command: openssl dhparam -out /etc/ssl/certs/dhparams.pem 2048 creates=/etc/ssl/certs/dhparams.pem


### PR DESCRIPTION
rename variables to match latest code: 
ssl_key -> nginx_ssl_key
ssl_crt -> nginx_ssl_crt